### PR TITLE
Indicate support for React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack": "^2.5.1"
   },
   "peerDependencies": {
-    "react": "^15.5.4"
+    "react": "^15.5.4 || ^16.8.0 || ^17.0.0 || ^18.0.0",
   },
   "scripts": {
     "build": "npm run build-dev && npm run build-prod",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack": "^2.5.1"
   },
   "peerDependencies": {
-    "react": "^15.5.4 || ^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "scripts": {
     "build": "npm run build-dev && npm run build-prod",


### PR DESCRIPTION
Indicate support for React 18 making it install on up to react 18 without using -force. I have tested a few runkit examples on React 18 and they all seem to work like expected.